### PR TITLE
Basic .deb package with postinst script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 aws-sdk-cpp
 iam
 
+libnss-iam-*.deb
+libnss-iam-*/
+
 # Object files
 *.o
 *.ko

--- a/Makefile
+++ b/Makefile
@@ -74,3 +74,31 @@ deps:
 	mkdir -p aws-sdk-cpp/build
 	(cd aws-sdk-cpp/build; cmake .. -DCMAKE_BUILD_TYPE=RelWithDebInfo -DBUILD_ONLY="monitoring;sts;iam" -DBUILD_SHARED_LIBS=false)
 	(cd aws-sdk-cpp/build; make -j 1)
+
+DPKG_VERSION=0.1
+DPKG_ROOT=libnss-iam-$(DPKG_VERSION)
+deb:
+	mkdir -p "$(DPKG_ROOT)/DEBIAN"
+	
+	echo -e \
+Package: libnss-iam                                       \\n\
+Version: $(DPKG_VERSION)                                  \\n\
+Architecture: amd64                                       \\n\
+Maintainer: George Fleury \<gfleury@gmail.com\>           \\n\
+Homepage: https://github.com/gfleury/libnss-iam           \\n\
+Description: Lib NSS module to integrate IAM users/groups \\n\
+> "$(DPKG_ROOT)/DEBIAN/control"
+
+	echo -e \
+\#!/bin/sh   \\n\
+set -e       \\n\
+ldconfig -n  \\n\
+exit 0       \\n\
+> "$(DPKG_ROOT)/DEBIAN/postinst" && chmod 755 "$(DPKG_ROOT)/DEBIAN/postinst"
+	
+	mkdir -p "$(DPKG_ROOT)/lib/"
+	cp "libnss_iam.so.2" "$(DPKG_ROOT)/lib/libnss_iam-$(DPKG_VERSION).so"
+	chmod 644 "$(DPKG_ROOT)/lib/libnss_iam-$(DPKG_VERSION).so"
+	cd "$(DPKG_ROOT)/lib" && ln -fs "libnss_iam-$(DPKG_VERSION).so" "libnss_iam.so.2"
+
+	dpkg-deb --build "$(DPKG_ROOT)"

--- a/README.md
+++ b/README.md
@@ -17,11 +17,18 @@ Build libnss_iam.so.2:
 libnss-iam$ make
 ```
 
+Build .deb package
+```
+# This can be done on an ubuntu 16.04 or 18.04 host
+libnss-iam$ make deb
+```
+
 ## Docker Simulator
 A simulator is provided to test installing and using libnss_iam.so.2
 
 AWS: You'll need an IAM user with ssh public key set
-```# The user level AWS shared creds file should have [default] set correctly in `~/.aws/credentials`
+```
+# The user level AWS shared creds file should have [default] set correctly in '~/.aws/credentials'
 [default]
 assumed_role = False
 aws_access_key_id = ...
@@ -37,8 +44,11 @@ Start/Configure the simulator:
 libnss-iam/docker$ make docker-build
 libnss-iam/docker$ make docker-shell
 
-# install libnss_iam.so.2
+# install libnss_iam.so.2 (Makefile)
 root@bastion-service:/libnss-iam# make install
+or
+# install libnss_iam.so.2 (.deb package)
+root@bastion-service:/# dpkg -i /libnss-iam/libnss-iam-0.1.deb
 
 # Start sshd
 root@bastion-service:/libnss-iam# /usr/sbin/sshd -d


### PR DESCRIPTION
This is a bit nicer in terms of installation than copying around the .so file.

Building the `.deb` file is hideous, but seems to be the 'simplest' means of doing so.

The README is updated to mention how to install into the simulator using the `.deb` file.
