### PR TITLE
ubuntu-18.04 support, default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: cpp 
 sudo: required
-dist: xenial 
+dist: bionic 
 os:
   - linux
 install: make deps 
@@ -15,7 +15,7 @@ compiler:
 #      - cmake-data
 #      - cmake
 before_install:
-  - sudo apt-get update && sudo apt-get install -y build-essential cmake git zlib1g zlib1g-dev libssl-dev libcurl3 libcurl3-openssl-dev
+  - sudo apt-get update && sudo apt-get install -y build-essential cmake git zlib1g-dev libssl-dev libcurl4-openssl-dev
   - echo $LANG
   - echo $LC_ALL
 script:

--- a/Dockerfile.ubuntu-18-04
+++ b/Dockerfile.ubuntu-18-04
@@ -1,0 +1,20 @@
+FROM ubuntu:18.04
+
+# Setup non-root user
+ARG nonroot_user
+ARG nonroot_uid
+
+RUN groupadd -g ${nonroot_uid} ${nonroot_user}
+RUN useradd -u ${nonroot_uid} -g ${nonroot_uid} -m ${nonroot_user}
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV TZ=UTC
+
+RUN apt-get update      \
+ && apt-get install -y  \
+    build-essential     \
+    cmake               \
+    git                 \
+    zlib1g-dev          \
+    libssl-dev          \
+    libcurl4-openssl-dev

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ install:
 	cd ${prefix}/lib && ln -fs libnss_iam-2.3.6.so libnss_iam.so.2
 	ldconfig -n
 
-DISTRO=ubuntu-16-04
+DISTRO=ubuntu-18-04
 docker-build:
 	docker build -t "sdk-builder-$(DISTRO)"    \
 	    --build-arg nonroot_user=$(user_name)  \

--- a/integration-tests/sshd/Dockerfile.ubuntu-18-04
+++ b/integration-tests/sshd/Dockerfile.ubuntu-18-04
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:18.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV TZ=UTC
@@ -16,8 +16,8 @@ RUN apt-get update      \
 RUN apt-get update      \
  && apt-get install -y  \
  zlib1g                 \
- libssl1.0              \
- libcurl3
+ libssl1.1              \
+ libcurl4
 
 RUN mkdir /var/run/sshd
 

--- a/integration-tests/sshd/Makefile
+++ b/integration-tests/sshd/Makefile
@@ -1,6 +1,6 @@
 SHELL=/bin/bash
 
-DISTRO=ubuntu-16-04
+DISTRO=ubuntu-18-04
 
 docker-build:
 	docker build -t "sshd-worker-$(DISTRO)" --file ./Dockerfile.$(DISTRO) .


### PR DESCRIPTION
What does this do ?
* build / integration-test support for openssl-1.1+ / curl4 used by ubuntu versions 18.04+
* sets travis-CI / docker-build defaults to this build target

The build artifact from this could be used for a first release.

Related#: #5 